### PR TITLE
Handle FinishUpload/compose call with empty object names #360

### DIFF
--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -129,6 +129,10 @@ const COMPOSE_RETRIES = 3
 
 // Compose takes a bucket name, a list of initial source names, and a destination string to compose multiple GCS objects together
 func (service *GCSService) compose(ctx context.Context, bucket string, srcs []string, dst string) error {
+	if len(srcs) < 1 {
+		return fmt.Errorf("empty srcs passed to compose for bucket: %s dest: %s", bucket, dst)
+	}
+
 	dstParams := GCSObjectParams{
 		Bucket: bucket,
 		ID:     dst,

--- a/pkg/gcsstore/gcsservice_test.go
+++ b/pkg/gcsstore/gcsservice_test.go
@@ -192,6 +192,30 @@ func TestComposeObjects(t *testing.T) {
 	}
 }
 
+func TestComposeNoObjects(t *testing.T) {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx, option.WithAPIKey("foo"))
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	service := GCSService{
+		Client: client,
+	}
+
+	err = service.ComposeObjects(ctx, GCSComposeParams{
+		Bucket:      "test-bucket",
+		Sources:     []string{},
+		Destination: "test_all",
+	})
+
+	if err == nil {
+		t.Errorf("Error: %v", err)
+		return
+	}
+}
+
 func TestGetObjectAttrs(t *testing.T) {
 	defer gock.Off()
 

--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -270,6 +270,10 @@ func (upload gcsUpload) FinishUpload(ctx context.Context) error {
 		return err
 	}
 
+	if len(names) == 0 {
+		return fmt.Errorf("no GCS objects found with FilterObjects %+v", filterParams)
+	}
+
 	composeParams := GCSComposeParams{
 		Bucket:      store.Bucket,
 		Destination: store.keyWithPrefix(id),


### PR DESCRIPTION
This should fix index out of range panics we see when FinishUpload is called with an empty slice of object names to compose.