### PR TITLE
Allow setting a custom Upload ID for FileStore

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -49,9 +49,10 @@ func (store FileStore) UseIn(composer *handler.StoreComposer) {
 }
 
 func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (handler.Upload, error) {
-	id := uid.Uid()
-	binPath := store.binPath(id)
-	info.ID = id
+	if info.ID == "" {
+		info.ID = uid.Uid()
+	}
+	binPath := store.binPath(info.ID)
 	info.Storage = map[string]string{
 		"Type": "filestore",
 		"Path": binPath,
@@ -72,8 +73,8 @@ func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (ha
 
 	upload := &fileUpload{
 		info:     info,
-		infoPath: store.infoPath(id),
-		binPath:  store.binPath(id),
+		infoPath: store.infoPath(info.ID),
+		binPath:  binPath,
 	}
 
 	// writeInfo creates the file by itself if necessary


### PR DESCRIPTION
The other DataStore implementations allow this. Not supporting it
in FileStore leads to inconsistent behavior. It's also a nice feature
for custom server implementations based on tusd.