### PR TITLE
Remove writing of info file in GCS in GetInfo method

### DIFF
--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -229,11 +229,6 @@ func (upload gcsUpload) GetInfo(ctx context.Context) (handler.FileInfo, error) {
 	}
 
 	info.Offset = offset
-	err = store.writeInfo(ctx, store.keyWithPrefix(id), info)
-	if err != nil {
-		return info, err
-	}
-
 	return info, nil
 }
 


### PR DESCRIPTION
This change removes an unnecessary call to `store.WriteInfo` in GCS store's `GetInfo` method. Prior to this change all `HEAD` requests were triggering a write to GCS.