### PR TITLE
gcsstore: Perform multiple API calls for compose and delete operations concurrently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0
 	github.com/stretchr/testify v1.4.0
 	github.com/vimeo/go-util v1.2.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/api v0.6.0
 	google.golang.org/grpc v1.28.0
 	gopkg.in/Acconut/lockfile.v1 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -331,12 +331,7 @@ func (service *GCSService) ComposeFrom(ctx context.Context, objSrcs []*storage.O
 	dstObj := service.Client.Bucket(dstParams.Bucket).Object(dstParams.ID)
 	c := dstObj.ComposerFrom(objSrcs...)
 	c.ContentType = contentType
-	_, err := c.Run(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	dstAttrs, err := dstObj.Attrs(ctx)
+	dstAttrs, err := c.Run(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"math"
 	"strconv"
 	"strings"
 
@@ -218,7 +217,7 @@ func (service *GCSService) recursiveCompose(ctx context.Context, srcs []string, 
 		return nil
 	}
 
-	tmpSrcLen := int(math.Ceil(float64(len(srcs)) / float64(MAX_OBJECT_COMPOSITION)))
+	tmpSrcLen := (len(srcs) + MAX_OBJECT_COMPOSITION - 1) / MAX_OBJECT_COMPOSITION
 	tmpSrcs := make([]string, tmpSrcLen)
 
 	for i := 0; i < tmpSrcLen; i++ {

--- a/pkg/gcsstore/gcsservice_test.go
+++ b/pkg/gcsstore/gcsservice_test.go
@@ -132,13 +132,6 @@ func TestComposeObjects(t *testing.T) {
 		JSON(map[string]string{})
 
 	gock.New("https://www.googleapis.com").
-		Get("/storage/v1/b/test-bucket/o/test1").
-		MatchParam("alt", "json").
-		MatchParam("projection", "full").
-		Reply(200).
-		JSON(map[string]string{})
-
-	gock.New("https://www.googleapis.com").
 		Post("/storage/v1/b/test-bucket/o/test_all/compose").
 		MatchParam("alt", "json").
 		Reply(200).


### PR DESCRIPTION
GCS only allows composing up to 32 objects at once with a single API call. However, with small chunks, the final compose required at the end of uploading can have hundreds of objects. Performing all of the required API calls sequentially is unnecessarily slow.

Additionally, the temporary objects are deleted using a single API call per object. All of these deletes can be performed concurrently to improve performance.

An optional parameter, MaxConcurrency, is added to GCSService to control how much concurrency is used per operation. The default is 256.